### PR TITLE
enable cross-origin resource sharing

### DIFF
--- a/chapter9/server/index.js
+++ b/chapter9/server/index.js
@@ -3,6 +3,13 @@ const bodyParser = require('body-parser');
 const app = express()
 
 app.use(bodyParser());
+
+app.use(function (req, res, next) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+});
+
 app.get('/', (req, res) => res.send('Hello World!'));
 
 app.get('/api/fail', (req, res) => res.status(403).json({msg: 'You are not allowed to access this'}));


### PR DESCRIPTION
I don't enable cross-origin, error throw when calling API

```
Failed to load http://localhost:3000/api/stock: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:4200' is therefore not allowed access.
```